### PR TITLE
Bump flutter version up.

### DIFF
--- a/.github/workflows/build-flutter.yml
+++ b/.github/workflows/build-flutter.yml
@@ -14,7 +14,8 @@ jobs:
         java-version: '11'
     - uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.7.7'
+        channel: 'stable'
+        architecture: x64
     - run: flutter pub get
     - run: flutter analyze --no-fatal-infos
     - run: flutter build apk

--- a/.github/workflows/build-flutter.yml
+++ b/.github/workflows/build-flutter.yml
@@ -14,7 +14,7 @@ jobs:
         java-version: '11'
     - uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.3.9'
+        flutter-version: '3.7.7'
     - run: flutter pub get
     - run: flutter analyze --no-fatal-infos
     - run: flutter build apk


### PR DESCRIPTION
Closes #315 

![image](https://github.com/OWASP/BLT-Flutter/assets/37345795/c73c9174-95d3-47b2-9960-d43f06045410)

This method was introduced in Flutter v3.7.0-32.0.pre

build-flutter.yml workflow uses v3.3.9 which seems to be the cause of the problem. I have configured the workflow in such a way that it would use the latest stable version of flutter.