### PR TITLE
Fix version incompatibility

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
    <application
         android:label="blt"
+        android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,9 @@ dependencies:
   google_fonts: ">=3.0.1 <5.0.0"
   http: ^0.13.1
   image_picker: ^0.8.4+4
-  receive_sharing_intent: ^1.4.5
+  receive_sharing_intent:
+    git:
+      url: https://github.com/Thogsit/receive_sharing_intent
   shared_preferences: ^2.0.5
   flutter_svg: ">=1.0.3 <3.0.0"
   flutter_riverpod: ^1.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: blt
 description: The BLT-Flutter App
 
 version: 1.0.3+1
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Closes #317 

Project is using an older version of gradle, which is incompatible with one of the dependencies - `package_info_plus`

Bumping up the gradle version causes another issue - `receive_sharing_intent` is not compatible with the latest gradle. There is an [open PR](https://github.com/KasemJaffer/receive_sharing_intent/pull/239) on `receive_sharing_intent`, which will make it compatible with the latest gradle. Until it is merged, we will use https://github.com/Thogsit/receive_sharing_intent instead of the official receive_sharing_intent.