### PR TITLE
Add logic for caching images locally.

### DIFF
--- a/android/app/src/main/java/io/flutter/app/FlutterMultiDexApplication.java
+++ b/android/app/src/main/java/io/flutter/app/FlutterMultiDexApplication.java
@@ -1,0 +1,25 @@
+// Generated file.
+//
+// If you wish to remove Flutter's multidex support, delete this entire file.
+//
+// Modifications to this file should be done in a copy under a different name
+// as this file may be regenerated.
+
+package io.flutter.app;
+
+import android.app.Application;
+import android.content.Context;
+import androidx.annotation.CallSuper;
+import androidx.multidex.MultiDex;
+
+/**
+ * Extension of {@link android.app.Application}, adding multidex support.
+ */
+public class FlutterMultiDexApplication extends Application {
+  @Override
+  @CallSuper
+  protected void attachBaseContext(Context base) {
+    super.attachBaseContext(base);
+    MultiDex.install(this);
+  }
+}

--- a/lib/src/components/contributor_card.dart
+++ b/lib/src/components/contributor_card.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -78,7 +79,7 @@ class ContributorCard extends StatelessWidget {
                                 child: CircleAvatar(
                                   radius: 32,
                                   backgroundImage:
-                                      NetworkImage(contributor["img"]!),
+                                  CachedNetworkImageProvider(contributor["img"]!),
                                 ),
                               ),
                             ),

--- a/lib/src/components/issue_intro_card.dart
+++ b/lib/src/components/issue_intro_card.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -39,8 +40,8 @@ class IssueCard extends StatelessWidget {
                 height: 0.214 * size.height,
                 child: AspectRatio(
                   aspectRatio: size.width / 0.214 * size.height,
-                  child: Image.network(
-                    issue.screenshotsLink![0],
+                  child: CachedNetworkImage(
+                    imageUrl: issue.screenshotsLink![0],
                     fit: BoxFit.cover,
                   ),
                 ),

--- a/lib/src/pages/company_details.dart
+++ b/lib/src/pages/company_details.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../models/company_model.dart';
@@ -152,7 +153,7 @@ class _CompanyDetailPageState extends State<CompanyDetailPage> {
                   decoration: BoxDecoration(
                     color: companyColor.withOpacity(0.5),
                     image: DecorationImage(
-                      image: NetworkImage(
+                      image: CachedNetworkImageProvider(
                         "https://storage.googleapis.com/bhfiles/" +
                             widget.company.logoLink,
                       ),

--- a/lib/src/pages/drawer/about.dart
+++ b/lib/src/pages/drawer/about.dart
@@ -1,6 +1,7 @@
 import 'package:blt/src/components/contributor_card.dart';
 import 'package:blt/src/constants/about_constants.dart';
 import 'package:blt/src/util/api/general_api.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -176,7 +177,7 @@ class AboutPage extends StatelessWidget {
                               tag: "image${contributor["id"]}",
                               child: CircleAvatar(
                                 radius: 32,
-                                backgroundImage: NetworkImage(contributor["img"]!),
+                                backgroundImage: CachedNetworkImageProvider(contributor["img"]!),
                               ),
                             ),
                             SizedBox(

--- a/lib/src/pages/home/home.dart
+++ b/lib/src/pages/home/home.dart
@@ -7,6 +7,7 @@ import 'package:blt/src/providers/authstate_provider.dart';
 import 'package:blt/src/providers/login_provider.dart';
 import 'package:blt/src/routes/routing.dart';
 import 'package:blt/src/util/enums/login_type.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -152,14 +153,14 @@ class _HomeState extends ConsumerState<Home> {
     );
   }
 
-  NetworkImage? buildAvatar() {
+  CachedNetworkImageProvider? buildAvatar() {
     LoginType loginState = ref.watch(loginProvider);
 
     return loginState != LoginType.guest
         ? (currentUser!.pfpLink != null)
-            ? NetworkImage(currentUser!.pfpLink!)
+            ? CachedNetworkImageProvider(currentUser!.pfpLink!)
             : null
-        : NetworkImage(
+        : CachedNetworkImageProvider(
             currentUser!.pfpLink!,
           );
   }

--- a/lib/src/pages/home/leaderboard.dart
+++ b/lib/src/pages/home/leaderboard.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -42,7 +43,7 @@ class _LeaderBoardState extends ConsumerState<LeaderBoard> {
       else
         return CircleAvatar(
           foregroundImage:
-              NetworkImage("https://bhfiles.storage.googleapis.com/" + partUrl),
+          CachedNetworkImageProvider("https://bhfiles.storage.googleapis.com/" + partUrl),
           radius: 20,
         );
     } on Exception {
@@ -72,7 +73,7 @@ class _LeaderBoardState extends ConsumerState<LeaderBoard> {
         );
       else
         return CircleAvatar(
-          foregroundImage: NetworkImage(
+          foregroundImage: CachedNetworkImageProvider(
             "https://storage.googleapis.com/bhfiles/" + partUrl,
           ),
           radius: 20,

--- a/lib/src/pages/leaderboards/company_scoreboard.dart
+++ b/lib/src/pages/leaderboards/company_scoreboard.dart
@@ -1,4 +1,5 @@
 import 'package:blt/src/util/endpoints/leaderboard_endpoints.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -31,7 +32,7 @@ class _CompanyScoreBoardPageState extends State<CompanyScoreBoardPage> {
         );
       else
         return CircleAvatar(
-          foregroundImage: NetworkImage(
+          foregroundImage: CachedNetworkImageProvider(
             "https://storage.googleapis.com/bhfiles/" + partUrl,
           ),
           radius: 20,

--- a/lib/src/pages/leaderboards/global_leaderboard.dart
+++ b/lib/src/pages/leaderboards/global_leaderboard.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -43,7 +44,7 @@ class _GlobalLeaderBoardPageState extends State<GlobalLeaderBoardPage> {
       else
         return CircleAvatar(
           foregroundImage:
-              NetworkImage("https://bhfiles.storage.googleapis.com/" + partUrl),
+              CachedNetworkImageProvider("https://bhfiles.storage.googleapis.com/" + partUrl),
           radius: 20,
         );
     } on Exception {

--- a/lib/src/pages/leaderboards/monthly_leaderboard.dart
+++ b/lib/src/pages/leaderboards/monthly_leaderboard.dart
@@ -1,4 +1,5 @@
 import 'package:blt/src/providers/leaderboards/monthlyleaderboard_provider.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -32,7 +33,7 @@ class _MonthlyLeaderBoardPageState extends ConsumerState<MonthlyLeaderBoardPage>
       else
         return CircleAvatar(
           foregroundImage:
-              NetworkImage("https://bhfiles.storage.googleapis.com/" + partUrl),
+          CachedNetworkImageProvider("https://bhfiles.storage.googleapis.com/" + partUrl),
           radius: 20,
         );
     } on Exception {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   flutter_inappwebview: ^5.7.2+3
   font_awesome_flutter: ^10.4.0
   sentry_flutter: ^7.2.0
+  cached_network_image: ^3.2.3
   #flutter_lints: ^1.0.4
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,6 @@ dependencies:
   font_awesome_flutter: ^10.4.0
   sentry_flutter: ^7.2.0
   cached_network_image: ^3.2.3
-  #flutter_lints: ^1.0.4
 
 dev_dependencies:
   flutter_launcher_icons: ">=0.9.0 <0.13.0"


### PR DESCRIPTION
Closes #320 

I have added logic for caching all the network images locally. You can see that as soon as issues feed data is loaded from server, images are rendered instantly once cached. We can also cache the issues feed data, but that is beyond the scope of this PR.

PS. I have also enabled multidex support, absence of which was causing build issues at times.