### PR TITLE
switch the order of leaderboard so monthly is first #332

### DIFF
--- a/lib/src/pages/home/leaderboard.dart
+++ b/lib/src/pages/home/leaderboard.dart
@@ -124,146 +124,6 @@ class _LeaderBoardState extends ConsumerState<LeaderBoard> {
           ),
           Container(
             padding: EdgeInsets.fromLTRB(0, 0, 0, 12),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                ListTile(
-                  title: Text(
-                    "Global Leaderboard",
-                    style: GoogleFonts.ubuntu(
-                      textStyle: TextStyle(
-                        color: Color(0xFFDC4654),
-                        fontSize: 16,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                  trailing: IconButton(
-                    icon: Icon(
-                      Icons.arrow_forward_ios_rounded,
-                      color: Color(0xFFDC4654),
-                    ),
-                    onPressed: () {
-                      Navigator.pushNamed(
-                        context,
-                        RouteManager.globalLeaderboardPage,
-                      );
-                    },
-                  ),
-                ),
-                Text(
-                  "Find out the best of the best, the all time finest bug finders!",
-                  style: GoogleFonts.aBeeZee(
-                    textStyle: TextStyle(
-                      color: Color(0xFF737373),
-                    ),
-                  ),
-                ),
-                Container(
-                  height: 0.3 * size.height,
-                  padding: const EdgeInsets.fromLTRB(0, 20, 0, 10),
-                  child: Consumer(
-                    builder: (context, ref, child) {
-                      final globalLeaderboardList = ref.watch(
-                        globalLeaderBoardProvider,
-                      );
-                      return globalLeaderboardList!.when(
-                        data: (leaderList) {
-                          return InkWell(
-                            onTap: () {
-                              Navigator.pushNamed(
-                                context,
-                                RouteManager.globalLeaderboardPage,
-                              );
-                            },
-                            child: ListView.builder(
-                              padding: EdgeInsets.zero,
-                              itemCount: 3,
-                              shrinkWrap: true,
-                              itemBuilder: (context, index) {
-                                return ListTile(
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: index == 0
-                                        ? BorderRadius.only(
-                                            topLeft: Radius.circular(10),
-                                            topRight: Radius.circular(15),
-                                          )
-                                        : index == 2
-                                            ? BorderRadius.only(
-                                                bottomLeft: Radius.circular(10),
-                                                bottomRight:
-                                                    Radius.circular(10),
-                                              )
-                                            : BorderRadius.only(
-                                                topLeft: Radius.circular(0),
-                                              ),
-                                  ),
-                                  tileColor: index == 2
-                                      ? Color(0xFFC9AE5D).withOpacity(0.42)
-                                      : index == 1
-                                          ? Color(0xFFADD8E6).withOpacity(0.42)
-                                          : index == 0
-                                              ? Color(0xFFFFD700)
-                                                  .withOpacity(0.42)
-                                              : Colors.white,
-                                  leading:
-                                      buildAvatar(leaderList![index].image),
-                                  title: Text(
-                                    leaderList[index].user,
-                                    style: GoogleFonts.ubuntu(
-                                      textStyle: TextStyle(
-                                        color: Color(0xFFDC4654),
-                                      ),
-                                    ),
-                                    maxLines: 6,
-                                  ),
-                                  subtitle: Text(
-                                    leaderList[index].score.toString() +
-                                        " points",
-                                    style: GoogleFonts.aBeeZee(
-                                      textStyle: TextStyle(
-                                        color: Color(0xFF737373),
-                                        fontSize: 12,
-                                      ),
-                                    ),
-                                  ),
-                                  trailing: Text(
-                                    "# " + (index + 1).toString(),
-                                    style: GoogleFonts.ubuntu(
-                                      textStyle: TextStyle(
-                                        color: Color(0xFF737373),
-                                        fontSize: 15,
-                                        fontWeight: FontWeight.bold,
-                                      ),
-                                    ),
-                                  ),
-                                );
-                              },
-                            ),
-                          );
-                        },
-                        error: (error, stackTr) {
-                          return Center(
-                            child: Text(
-                              'Something went wrong!',
-                              style: TextStyle(fontSize: 18),
-                            ),
-                          );
-                        },
-                        loading: () {
-                          return Center(
-                            child: CircularProgressIndicator(),
-                          );
-                        },
-                      );
-                    },
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Container(
-            padding: EdgeInsets.fromLTRB(0, 0, 0, 12),
             color: Theme.of(context).canvasColor,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -403,6 +263,146 @@ class _LeaderBoardState extends ConsumerState<LeaderBoard> {
               ],
             ),
           ),
+          Container(
+                      padding: EdgeInsets.fromLTRB(0, 0, 0, 12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          ListTile(
+                            title: Text(
+                              "Global Leaderboard",
+                              style: GoogleFonts.ubuntu(
+                                textStyle: TextStyle(
+                                  color: Color(0xFFDC4654),
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                            trailing: IconButton(
+                              icon: Icon(
+                                Icons.arrow_forward_ios_rounded,
+                                color: Color(0xFFDC4654),
+                              ),
+                              onPressed: () {
+                                Navigator.pushNamed(
+                                  context,
+                                  RouteManager.globalLeaderboardPage,
+                                );
+                              },
+                            ),
+                          ),
+                          Text(
+                            "Find out the best of the best, the all time finest bug finders!",
+                            style: GoogleFonts.aBeeZee(
+                              textStyle: TextStyle(
+                                color: Color(0xFF737373),
+                              ),
+                            ),
+                          ),
+                          Container(
+                            height: 0.3 * size.height,
+                            padding: const EdgeInsets.fromLTRB(0, 20, 0, 10),
+                            child: Consumer(
+                              builder: (context, ref, child) {
+                                final globalLeaderboardList = ref.watch(
+                                  globalLeaderBoardProvider,
+                                );
+                                return globalLeaderboardList!.when(
+                                  data: (leaderList) {
+                                    return InkWell(
+                                      onTap: () {
+                                        Navigator.pushNamed(
+                                          context,
+                                          RouteManager.globalLeaderboardPage,
+                                        );
+                                      },
+                                      child: ListView.builder(
+                                        padding: EdgeInsets.zero,
+                                        itemCount: 3,
+                                        shrinkWrap: true,
+                                        itemBuilder: (context, index) {
+                                          return ListTile(
+                                            shape: RoundedRectangleBorder(
+                                              borderRadius: index == 0
+                                                  ? BorderRadius.only(
+                                                      topLeft: Radius.circular(10),
+                                                      topRight: Radius.circular(15),
+                                                    )
+                                                  : index == 2
+                                                      ? BorderRadius.only(
+                                                          bottomLeft: Radius.circular(10),
+                                                          bottomRight:
+                                                              Radius.circular(10),
+                                                        )
+                                                      : BorderRadius.only(
+                                                          topLeft: Radius.circular(0),
+                                                        ),
+                                            ),
+                                            tileColor: index == 2
+                                                ? Color(0xFFC9AE5D).withOpacity(0.42)
+                                                : index == 1
+                                                    ? Color(0xFFADD8E6).withOpacity(0.42)
+                                                    : index == 0
+                                                        ? Color(0xFFFFD700)
+                                                            .withOpacity(0.42)
+                                                        : Colors.white,
+                                            leading:
+                                                buildAvatar(leaderList![index].image),
+                                            title: Text(
+                                              leaderList[index].user,
+                                              style: GoogleFonts.ubuntu(
+                                                textStyle: TextStyle(
+                                                  color: Color(0xFFDC4654),
+                                                ),
+                                              ),
+                                              maxLines: 6,
+                                            ),
+                                            subtitle: Text(
+                                              leaderList[index].score.toString() +
+                                                  " points",
+                                              style: GoogleFonts.aBeeZee(
+                                                textStyle: TextStyle(
+                                                  color: Color(0xFF737373),
+                                                  fontSize: 12,
+                                                ),
+                                              ),
+                                            ),
+                                            trailing: Text(
+                                              "# " + (index + 1).toString(),
+                                              style: GoogleFonts.ubuntu(
+                                                textStyle: TextStyle(
+                                                  color: Color(0xFF737373),
+                                                  fontSize: 15,
+                                                  fontWeight: FontWeight.bold,
+                                                ),
+                                              ),
+                                            ),
+                                          );
+                                        },
+                                      ),
+                                    );
+                                  },
+                                  error: (error, stackTr) {
+                                    return Center(
+                                      child: Text(
+                                        'Something went wrong!',
+                                        style: TextStyle(fontSize: 18),
+                                      ),
+                                    );
+                                  },
+                                  loading: () {
+                                    return Center(
+                                      child: CircularProgressIndicator(),
+                                    );
+                                  },
+                                );
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
           Container(
             padding: EdgeInsets.fromLTRB(0, 0, 0, 12),
             color: Theme.of(context).canvasColor,


### PR DESCRIPTION
Before:
![1](https://github.com/OWASP/BLT-Flutter/assets/90714878/fafe1297-e2b6-454e-a370-b651e0e1a4fe)
After:
![2](https://github.com/OWASP/BLT-Flutter/assets/90714878/a4dfcb19-963a-4e09-9242-5d2f36ce156e)
I have resolved the issue of switching the order of the leaderboard so that the Monthly Leaderboard is displayed first. [BLT-Flutter Issue #332](https://github.com/OWASP/BLT-Flutter/issues/332)